### PR TITLE
snowflakes: Remove enabled switch & Translate

### DIFF
--- a/snowflakes/config/snowflakes.php
+++ b/snowflakes/config/snowflakes.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'enabled' => env('SNOWFLAKES_ENABLED', true),
     'size' => env('SNOWFLAKES_SIZE', 1),
     'speed' => env('SNOWFLAKES_SPEED', 3),
     'opacity' => env('SNOWFLAKES_OPACITY', 0.5),

--- a/snowflakes/lang/en/strings.php
+++ b/snowflakes/lang/en/strings.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'size' => 'Size',
+    'size_help' => 'Size of the snowflakes.',
+    'speed' => 'Speed',
+    'speed_help' => 'Speed of the snowflakes falling.',
+    'opacity' => 'Opacity',
+    'opacity_help' => 'How well can you see through the snowflakes.',
+    'density' => 'Density',
+    'density_help' => 'Page density of the snowflakes. More density, more snowflakes.',
+    'quality' => 'Quality',
+    'quality_help' => 'Higher quality may impact performance on some devices.',
+];

--- a/snowflakes/src/Providers/SnowflakesPluginProvider.php
+++ b/snowflakes/src/Providers/SnowflakesPluginProvider.php
@@ -11,19 +11,11 @@ class SnowflakesPluginProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        $enabled = config('snowflakes.enabled');
-        $size = config('snowflakes.size');
-        $speed = config('snowflakes.speed');
-        $opacity = config('snowflakes.opacity');
-        $density = config('snowflakes.density');
-        $quality = config('snowflakes.quality');
-
         FilamentView::registerRenderHook(
             PanelsRenderHook::PAGE_START,
             fn () => Blade::render(<<<'HTML'
             <script>
             window.SnowflakeConfig = {
-                start: {{ $enabled }},
                 size: {{ $size }},
                 speed: {{ $speed }},
                 opacity: {{ $opacity }},
@@ -34,14 +26,7 @@ class SnowflakesPluginProvider extends ServiceProvider
             };
             </script>
             <script src="https://cdn.jsdelivr.net/gh/nextapps-de/snowflake@master/snowflake.min.js"></script>
-            HTML, [
-                'enabled' => $enabled,
-                'size' => $size,
-                'speed' => $speed,
-                'opacity' => $opacity,
-                'density' => $density,
-                'quality' => $quality,
-            ])
+            HTML, config('snowflakes'))
         );
     }
 }

--- a/snowflakes/src/SnowflakesPlugin.php
+++ b/snowflakes/src/SnowflakesPlugin.php
@@ -27,49 +27,49 @@ class SnowflakesPlugin implements HasPluginSettings, Plugin
     {
         $schema = [
             Slider::make('SNOWFLAKES_SIZE')
+                ->label(trans('snowflakes::strings.size'))
                 ->range(minValue: 0.5, maxValue: 4)
                 ->decimalPlaces(1)
                 ->step(0.1)
-                ->label('Size')
                 ->tooltips()
                 ->hintIcon('tabler-question-mark')
-                ->hintIconTooltip('Size of the snowflakes.')
+                ->hintIconTooltip(trans('snowflakes::strings.size_help'))
                 ->default(fn () => config('snowflakes.size')),
             Slider::make('SNOWFLAKES_SPEED')
-                ->label('Speed')
+                ->label(trans('snowflakes::strings.speed'))
                 ->range(minValue: 0.5, maxValue: 3)
                 ->decimalPlaces(1)
                 ->step(0.1)
                 ->tooltips()
                 ->hintIcon('tabler-question-mark')
-                ->hintIconTooltip('Speed of the snowflakes falling.')
+                ->hintIconTooltip(trans('snowflakes::strings.speed_help'))
                 ->default(fn () => config('snowflakes.speed')),
             Slider::make('SNOWFLAKES_OPACITY')
-                ->label('Opacity')
+                ->label(trans('snowflakes::strings.opacity'))
                 ->range(minValue: 0.1, maxValue: 1)
                 ->decimalPlaces(1)
                 ->step(0.1)
                 ->tooltips()
                 ->hintIcon('tabler-question-mark')
-                ->hintIconTooltip('How well can you see through the snowflakes.')
+                ->hintIconTooltip(trans('snowflakes::strings.opacity_help'))
                 ->default(fn () => config('snowflakes.opacity')),
             Slider::make('SNOWFLAKES_DENSITY')
-                ->label('Density')
+                ->label(trans('snowflakes::strings.density'))
                 ->range(minValue: 0.5, maxValue: 10)
                 ->decimalPlaces(1)
                 ->step(0.1)
                 ->tooltips()
                 ->hintIcon('tabler-question-mark')
-                ->hintIconTooltip('Page density of the snowflakes. More density, more snowflakes.')
+                ->hintIconTooltip(trans('snowflakes::strings.density_help'))
                 ->default(fn () => config('snowflakes.density')),
             Slider::make('SNOWFLAKES_QUALITY')
-                ->label('Quality')
+                ->label(trans('snowflakes::strings.quality'))
                 ->range(minValue: 0.1, maxValue: 1)
                 ->decimalPlaces(1)
                 ->step(0.1)
                 ->tooltips()
                 ->hintIcon('tabler-question-mark')
-                ->hintIconTooltip('Higher quality may impact performance on some devices.')
+                ->hintIconTooltip(trans('snowflakes::strings.quality_help'))
                 ->default(fn () => config('snowflakes.quality')),
         ];
 
@@ -85,7 +85,7 @@ class SnowflakesPlugin implements HasPluginSettings, Plugin
         $this->writeToEnvironment($data);
 
         Notification::make()
-            ->title('Settings saved')
+            ->title(trans('admin/setting.save_success'))
             ->success()
             ->send();
     }

--- a/snowflakes/src/SnowflakesPlugin.php
+++ b/snowflakes/src/SnowflakesPlugin.php
@@ -6,7 +6,6 @@ use App\Contracts\Plugins\HasPluginSettings;
 use App\Traits\EnvironmentWriterTrait;
 use Filament\Contracts\Plugin;
 use Filament\Forms\Components\Slider;
-use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
 use Filament\Panel;
 use Filament\Schemas\Components\Group;
@@ -27,11 +26,6 @@ class SnowflakesPlugin implements HasPluginSettings, Plugin
     public function getSettingsForm(): array
     {
         $schema = [
-            Toggle::make('SNOWFLAKES_ENABLED')
-                ->label('Enable Snowflakes')
-                ->columnSpanFull()
-                ->live()
-                ->default(fn () => config('snowflakes.enabled')),
             Slider::make('SNOWFLAKES_SIZE')
                 ->range(minValue: 0.5, maxValue: 4)
                 ->decimalPlaces(1)
@@ -40,7 +34,6 @@ class SnowflakesPlugin implements HasPluginSettings, Plugin
                 ->tooltips()
                 ->hintIcon('tabler-question-mark')
                 ->hintIconTooltip('Size of the snowflakes.')
-                ->disabled(fn ($get) => !$get('SNOWFLAKES_ENABLED'))
                 ->default(fn () => config('snowflakes.size')),
             Slider::make('SNOWFLAKES_SPEED')
                 ->label('Speed')
@@ -50,7 +43,6 @@ class SnowflakesPlugin implements HasPluginSettings, Plugin
                 ->tooltips()
                 ->hintIcon('tabler-question-mark')
                 ->hintIconTooltip('Speed of the snowflakes falling.')
-                ->disabled(fn ($get) => !$get('SNOWFLAKES_ENABLED'))
                 ->default(fn () => config('snowflakes.speed')),
             Slider::make('SNOWFLAKES_OPACITY')
                 ->label('Opacity')
@@ -60,7 +52,6 @@ class SnowflakesPlugin implements HasPluginSettings, Plugin
                 ->tooltips()
                 ->hintIcon('tabler-question-mark')
                 ->hintIconTooltip('How well can you see through the snowflakes.')
-                ->disabled(fn ($get) => !$get('SNOWFLAKES_ENABLED'))
                 ->default(fn () => config('snowflakes.opacity')),
             Slider::make('SNOWFLAKES_DENSITY')
                 ->label('Density')
@@ -70,7 +61,6 @@ class SnowflakesPlugin implements HasPluginSettings, Plugin
                 ->tooltips()
                 ->hintIcon('tabler-question-mark')
                 ->hintIconTooltip('Page density of the snowflakes. More density, more snowflakes.')
-                ->disabled(fn ($get) => !$get('SNOWFLAKES_ENABLED'))
                 ->default(fn () => config('snowflakes.density')),
             Slider::make('SNOWFLAKES_QUALITY')
                 ->label('Quality')
@@ -80,7 +70,6 @@ class SnowflakesPlugin implements HasPluginSettings, Plugin
                 ->tooltips()
                 ->hintIcon('tabler-question-mark')
                 ->hintIconTooltip('Higher quality may impact performance on some devices.')
-                ->disabled(fn ($get) => !$get('SNOWFLAKES_ENABLED'))
                 ->default(fn () => config('snowflakes.quality')),
         ];
 
@@ -93,7 +82,6 @@ class SnowflakesPlugin implements HasPluginSettings, Plugin
 
     public function saveSettings(array $data): void
     {
-        $data['SNOWFLAKES_ENABLED'] = $data['SNOWFLAKES_ENABLED'] ? 'true' : 'false';
         $this->writeToEnvironment($data);
 
         Notification::make()


### PR DESCRIPTION
The switch doesn't do anything anyway, if you don't want snowflakes anymore disable the plugin.
<img width="484" height="20" alt="image" src="https://github.com/user-attachments/assets/a511b14e-48ba-4111-be41-b0efa71e3e65" />
> [The library will automatically start by default when loading the library. Just when autostart was disabled you'll need to initially call Snowflake.start().](https://github.com/nextapps-de/snowflake#showstart-snowflake)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the enable/disable toggle from snowflakes settings
  * Updated configuration labels and help text to use localized translation strings for better internationalization support
  * Streamlined configuration data handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->