### PR TITLE
Rename pelican-dev org references to pelican

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone Pelican Panel
-        run: git clone --depth=1 https://github.com/pelican/panel pelican
+        run: |
+          git clone --depth=1 https://github.com/pelican/panel pelican \
+            || git clone --depth=1 https://github.com/pelican-dev/panel pelican
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,9 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone Pelican Panel
-        run: |
-          git clone --depth=1 https://github.com/pelican/panel pelican \
-            || git clone --depth=1 https://github.com/pelican-dev/panel pelican
+        run: git clone --depth=1 https://github.com/pelican/panel pelican
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Clone Pelican Panel
-        run: git clone --depth=1 https://github.com/pelican-dev/panel pelican
+        run: git clone --depth=1 https://github.com/pelican/panel pelican
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ To start contributing you need to have a basic understanding of the following:
 
 You can find detailed information on how plugins work in [our documentation](https://pelican.dev/docs/panel/advanced/plugins#create-a-plugin).
 
-For information on setting up a panel dev environment, see the [contributing guide in the panel repo](https://github.com/pelican-dev/panel/blob/main/contributing.md#dev-environment-setup).
+For information on setting up a panel dev environment, see the [contributing guide in the panel repo](https://github.com/pelican/panel/blob/main/contributing.md#dev-environment-setup).
 
 ## Coding Standards
 
@@ -31,4 +31,4 @@ Also, please make sure that your pull requests are as targeted and simple as pos
 ## Community and Support
 
 * Help: [Discord](https://discord.gg/pelican-panel)
-* Bugs & Features: [GitHub Issues](https://github.com/pelican-dev/plugins/issues)
+* Bugs & Features: [GitHub Issues](https://github.com/pelican/plugins/issues)

--- a/subdomains/README.md
+++ b/subdomains/README.md
@@ -16,4 +16,4 @@ Note: You can't create subdomains for servers with `0.0.0.0` or `::` as allocati
 In order to create SRV records instead of A/AAAA you need to do the following:
 
 1. Set a `SRV target` for the node
-2. Add a [SRV service type](https://github.com/pelican-dev/plugins/blob/main/subdomains/src/Enums/SRVServiceType.php#L10-L15) to the features of the egg. The format is `srv-` and then the service name, e.g. `srv-minecraft` or `srv-rust`.
+2. Add a [SRV service type](https://github.com/pelican/plugins/blob/main/subdomains/src/Enums/SRVServiceType.php#L10-L15) to the features of the egg. The format is `srv-` and then the service name, e.g. `srv-minecraft` or `srv-rust`.


### PR DESCRIPTION
**Do not merge this yet.** Holding it as a draft until the org move is finished, since the new paths don't resolve before then.

Small diff, but one line in it is load-bearing: `.github/workflows/lint.yml` clones the panel repo to lint against, so until that URL resolves, CI in this repo fails at the checkout step rather than on anything to do with the actual code. Expect the PHPStan jobs here to be red in the meantime — that's the clone, not the plugins.

The other three are links in `CONTRIBUTING.md` and `subdomains/README.md`. The subdomains README is the source for the mirrored `plugin-subdomains` repo, so that one gets picked up automatically and doesn't need its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidance and SRV record documentation links to the current repository locations.
- **Chores**
  - Updated automated workflow references to use the current repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->