### PR TITLE
Subdomains domain prefix

### DIFF
--- a/subdomains/README.md
+++ b/subdomains/README.md
@@ -11,6 +11,12 @@ By default every server has a subdomain limit of 0. You can change this limit by
 
 Note: You can't create subdomains for servers with `0.0.0.0` or `::` as allocation!
 
+## Configuring domains
+
+Each domain is composed of a name and an optional prefix. The name must be a valid Cloudflare Zone ID, while the prefix can be used to specify a subdomain on which the server subdomains will be created.
+
+For example: when creating a subdomain `server1` on a domain with name `example.com` and prefix `abc`, the created record will be `server1.abc.example.com`.
+
 ## SRV Records
 
 In order to create SRV records instead of A/AAAA you need to do the following:

--- a/subdomains/README.md
+++ b/subdomains/README.md
@@ -13,7 +13,7 @@ Note: You can't create subdomains for servers with `0.0.0.0` or `::` as allocati
 
 ## Configuring domains
 
-Each domain is composed of a name and an optional prefix. The name must be a valid Cloudflare Zone ID, while the prefix can be used to specify a subdomain on which the server subdomains will be created.
+Each domain is composed of a name and an optional prefix. The name must be a valid Cloudflare Zone, while the prefix can be used to specify a subdomain on which the server subdomains will be created.
 
 For example: when creating a subdomain `server1` on a domain with name `example.com` and prefix `abc`, the created record will be `server1.abc.example.com`.
 

--- a/subdomains/database/migrations/005_add_prefix_to_cloudflare_domains.php
+++ b/subdomains/database/migrations/005_add_prefix_to_cloudflare_domains.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('cloudflare_domains', function (Blueprint $table) {
+            $table->string('prefix')->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cloudflare_domains', function (Blueprint $table) {
+            $table->dropColumn('prefix');
+        });
+    }
+};

--- a/subdomains/lang/de/strings.php
+++ b/subdomains/lang/de/strings.php
@@ -13,6 +13,7 @@ return [
     'create_subdomain' => 'Subdomain erstellen',
 
     'name' => 'Name',
+    'prefix' => 'Präfix',
     'record_type' => 'Record Typ',
     'is_synced' => 'Ist synchronisiert?',
     'srv_target' => 'SRV Ziel',

--- a/subdomains/lang/en/strings.php
+++ b/subdomains/lang/en/strings.php
@@ -13,6 +13,7 @@ return [
     'create_subdomain' => 'Create Subdomain',
 
     'name' => 'Name',
+    'prefix' => 'Prefix',
     'record_type' => 'Record type',
     'is_synced' => 'Is Synced?',
     'srv_target' => 'SRV target',

--- a/subdomains/src/Filament/Admin/Resources/CloudflareDomains/CloudflareDomainResource.php
+++ b/subdomains/src/Filament/Admin/Resources/CloudflareDomains/CloudflareDomainResource.php
@@ -56,6 +56,8 @@ class CloudflareDomainResource extends Resource
             ->columns([
                 TextColumn::make('name')
                     ->label(trans('subdomains::strings.name')),
+                TextColumn::make('prefix')
+                    ->label(trans('subdomains::strings.prefix')),
                 TextColumn::make('subdomains_count')
                     ->label(trans_choice('subdomains::strings.subdomain', 2))
                     ->counts('subdomains'),
@@ -116,12 +118,14 @@ class CloudflareDomainResource extends Resource
     public static function form(Schema $schema): Schema
     {
         return $schema
-            ->columns(1)
+            ->columns(2)
             ->components([
                 TextInput::make('name')
                     ->label(trans('subdomains::strings.name'))
                     ->required()
                     ->unique(),
+                TextInput::make('prefix')
+                    ->label(trans('subdomains::strings.prefix')),
             ]);
     }
 

--- a/subdomains/src/Filament/Admin/Resources/Servers/RelationManagers/SubdomainRelationManager.php
+++ b/subdomains/src/Filament/Admin/Resources/Servers/RelationManagers/SubdomainRelationManager.php
@@ -116,7 +116,7 @@ class SubdomainRelationManager extends RelationManager
                     ->alphaDash()
                     ->rule(new NotOnBlacklist())
                     ->columnSpanFull()
-                    ->suffix(fn (Get $get) => '.' . CloudflareDomain::find($get('domain_id'))?->name),
+                    ->suffix(fn (Get $get) => '.' . CloudflareDomain::find($get('domain_id'))?->nameWithPrefix()),
                 Select::make('domain_id')
                     ->label(trans_choice('subdomains::strings.domain', 1))
                     ->disabledOn('edit')

--- a/subdomains/src/Filament/Server/Resources/Subdomains/SubdomainResource.php
+++ b/subdomains/src/Filament/Server/Resources/Subdomains/SubdomainResource.php
@@ -147,7 +147,7 @@ class SubdomainResource extends Resource
                     ->alphaDash()
                     ->rule(new NotOnBlacklist())
                     ->columnSpanFull()
-                    ->suffix(fn (Get $get) => '.' . CloudflareDomain::find($get('domain_id'))?->name),
+                    ->suffix(fn (Get $get) => '.' . CloudflareDomain::find($get('domain_id'))?->nameWithPrefix()),
                 Select::make('domain_id')
                     ->label(trans_choice('subdomains::strings.domain', 1))
                     ->disabledOn('edit')

--- a/subdomains/src/Models/CloudflareDomain.php
+++ b/subdomains/src/Models/CloudflareDomain.php
@@ -10,12 +10,14 @@ use Illuminate\Support\Facades\Http;
 /**
  * @property int $id
  * @property string $name
+ * @property ?string $prefix
  * @property ?string $cloudflare_id
  */
 class CloudflareDomain extends Model
 {
     protected $fillable = [
         'name',
+        'prefix',
         'cloudflare_id',
     ];
 
@@ -31,6 +33,11 @@ class CloudflareDomain extends Model
     public function subdomains(): HasMany
     {
         return $this->hasMany(Subdomain::class, 'domain_id');
+    }
+
+    public function prependPrefix(string $subdomain): string
+    {
+        return is_null($this->prefix) ? $subdomain : "$subdomain.$this->prefix";
     }
 
     /** @throws Exception */

--- a/subdomains/src/Models/CloudflareDomain.php
+++ b/subdomains/src/Models/CloudflareDomain.php
@@ -35,6 +35,11 @@ class CloudflareDomain extends Model
         return $this->hasMany(Subdomain::class, 'domain_id');
     }
 
+    public function nameWithPrefix(): string
+    {
+        return is_null($this->prefix) ? $this->name : "$this->prefix.$this->name";
+    }
+
     public function prependPrefix(string $subdomain): string
     {
         return is_null($this->prefix) ? $subdomain : "$subdomain.$this->prefix";

--- a/subdomains/src/Models/Subdomain.php
+++ b/subdomains/src/Models/Subdomain.php
@@ -75,7 +75,7 @@ class Subdomain extends Model implements HasLabel
                 throw new Exception('Server has no SRV type');
             }
 
-            $searchName = "$srvServiceType->value.$this->name";
+            $searchName = $this->domain->prependPrefix("$srvServiceType->value.$this->name");
 
             $payload = [
                 'name' => $searchName,

--- a/subdomains/src/Models/Subdomain.php
+++ b/subdomains/src/Models/Subdomain.php
@@ -52,7 +52,7 @@ class Subdomain extends Model implements HasLabel
 
     public function getLabel(): string|Htmlable|null
     {
-        return $this->name . '.' . $this->domain->name;
+        return $this->name . '.' . $this->domain->nameWithPrefix();
     }
 
     /** @throws Exception */
@@ -94,7 +94,7 @@ class Subdomain extends Model implements HasLabel
                 throw new Exception('Server has invalid allocation ip (0.0.0.0 or ::)');
             }
 
-            $searchName = $this->name;
+            $searchName = $this->domain->prependPrefix($this->name);
 
             $payload = [
                 'name' => $searchName,


### PR DESCRIPTION
Adds an optional `prefix` field to CloudflareDomain, so server subdomains can be defined on subdomains of the domain.

For now, I left uniqueness logic as it was before (unique constraint on domain name only). Do we want to change that to be unique name+prefix, so multiple prefixes can be created for the same domain?

Closes #139 (blacklist was implemented previously by Boy132)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional prefixes for configured domains.
  * Domain forms and listings now support editing and viewing prefixes.
  * Subdomain creation and DNS records consistently reflect configured domain prefixes.
  * Added English and German translations for the new prefix field.

* **Documentation**
  * Added guidance and examples for configuring domain names and prefixes, including how prefixes affect created DNS records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->