### PR TITLE
feat(generic-oidc-providers): add PKCE support

### DIFF
--- a/generic-oidc-providers/database/migrations/003_add_use_pkce.php
+++ b/generic-oidc-providers/database/migrations/003_add_use_pkce.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('generic_oidc_providers', function (Blueprint $table) {
+            $table->boolean('use_pkce')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('generic_oidc_providers', function (Blueprint $table) {
+            $table->dropColumn('use_pkce');
+        });
+    }
+};

--- a/generic-oidc-providers/lang/de/strings.php
+++ b/generic-oidc-providers/lang/de/strings.php
@@ -10,4 +10,5 @@ return [
     'redirect_url' => 'Weiterleitungs-URL',
     'verify_jwt' => 'JWT verifizieren?',
     'jwt_public_key' => 'JWT Public Key',
+    'use_pkce' => 'PKCE verwenden?',
 ];

--- a/generic-oidc-providers/lang/en/strings.php
+++ b/generic-oidc-providers/lang/en/strings.php
@@ -10,4 +10,5 @@ return [
     'redirect_url' => 'Redirect URL',
     'verify_jwt' => 'Verify JWT?',
     'jwt_public_key' => 'JWT Public Key',
+    'use_pkce' => 'Use PKCE?',
 ];

--- a/generic-oidc-providers/plugin.json
+++ b/generic-oidc-providers/plugin.json
@@ -2,7 +2,7 @@
     "id": "generic-oidc-providers",
     "name": "Generic OIDC Providers",
     "author": "Boy132",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Allows to create generic OIDC providers.",
     "category": "plugin",
     "url": "https://hub.pelican.dev/plugins/generic-oidc-providers",

--- a/generic-oidc-providers/src/Extensions/OAuth/Providers/GenericOIDCProvider.php
+++ b/generic-oidc-providers/src/Extensions/OAuth/Providers/GenericOIDCProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Boy132\GenericOIDCProviders\Extensions\OAuth\Providers;
+
+use Override;
+use SocialiteProviders\OIDC\Provider;
+
+final class GenericOIDCProvider extends Provider
+{
+    /**
+     * @return string[]
+     */
+    public static function additionalConfigKeys(): array
+    {
+        return array_merge(parent::additionalConfigKeys(), ['use_pkce']);
+    }
+
+    #[Override]
+    protected function usesPKCE(): bool
+    {
+        $configured = $this->config['use_pkce'] ?? null;
+
+        if (!is_null($configured)) {
+            return $configured;
+        }
+
+        $openid_config = $this->getOpenIdConfig();
+        if (isset($openid_config['code_challenge_methods_supported']) && in_array('S256', $openid_config['code_challenge_methods_supported'])) {
+            return true;
+        }
+
+        return parent::usesPKCE();
+    }
+}

--- a/generic-oidc-providers/src/Extensions/OAuth/Schemas/GenericOIDCProviderSchema.php
+++ b/generic-oidc-providers/src/Extensions/OAuth/Schemas/GenericOIDCProviderSchema.php
@@ -4,13 +4,13 @@ namespace Boy132\GenericOIDCProviders\Extensions\OAuth\Schemas;
 
 use App\Extensions\OAuth\Schemas\OAuthSchema;
 use App\Models\User;
+use Boy132\GenericOIDCProviders\Extensions\OAuth\Providers\GenericOIDCProvider as Provider;
 use Boy132\GenericOIDCProviders\Filament\Admin\Resources\GenericOIDCProviders\Pages\EditGenericOIDCProvider;
 use Boy132\GenericOIDCProviders\Models\GenericOIDCProvider;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Wizard\Step;
 use Illuminate\Support\Str;
 use Laravel\Socialite\Contracts\User as OAuthUser;
-use SocialiteProviders\OIDC\Provider;
 
 final class GenericOIDCProviderSchema extends OAuthSchema
 {
@@ -34,6 +34,7 @@ final class GenericOIDCProviderSchema extends OAuthSchema
             'base_url' => $this->model->base_url,
             'verify_jwt' => $this->model->verify_jwt,
             'jwt_public_key' => $this->model->jwt_public_key,
+            'use_pkce' => $this->model->use_pkce,
         ];
     }
 

--- a/generic-oidc-providers/src/Filament/Admin/Resources/GenericOIDCProviders/GenericOIDCProviderResource.php
+++ b/generic-oidc-providers/src/Filament/Admin/Resources/GenericOIDCProviders/GenericOIDCProviderResource.php
@@ -117,7 +117,7 @@ class GenericOIDCProviderResource extends Resource
                     ->revealable()
                     ->autocomplete(false),
                 Group::make()
-                    ->columns(3)
+                    ->columns(4)
                     ->columnSpanFull()
                     ->schema([
                         Toggle::make('create_missing_users')
@@ -145,6 +145,13 @@ class GenericOIDCProviderResource extends Resource
                             ->offColor('danger')
                             ->stateCast(new BooleanStateCast(false))
                             ->live(),
+                        Select::make('use_pkce')
+                            ->label(trans('generic-oidc-providers::strings.use_pkce'))
+                            ->nullable()
+                            ->boolean(
+                                trans('admin/server.yes'),
+                                trans('admin/server.no'),
+                            ),
                     ]),
                 Textarea::make('jwt_public_key')
                     ->label(trans('generic-oidc-providers::strings.jwt_public_key'))
@@ -188,6 +195,13 @@ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...
                 IconColumn::make('link_missing_users')
                     ->label(trans('admin/setting.oauth.link_missing_users'))
                     ->boolean(),
+                IconColumn::make('use_pkce')
+                    ->label(trans('generic-oidc-providers::strings.use_pkce'))
+                    ->boolean()
+                    // null is "blank" and would render nothing, so show it as 'auto'
+                    ->default('auto')
+                    ->icon(fn ($state) => $state === 'auto' ? 'tabler-wand' : null)
+                    ->color(fn ($state) => $state === 'auto' ? 'gray' : null),
             ])
             ->recordActions([
                 EditAction::make(),

--- a/generic-oidc-providers/src/Models/GenericOIDCProvider.php
+++ b/generic-oidc-providers/src/Models/GenericOIDCProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $client_secret
  * @property bool $verify_jwt
  * @property ?string $jwt_public_key
+ * @property ?bool $use_pkce
  */
 class GenericOIDCProvider extends Model
 {
@@ -35,6 +36,7 @@ class GenericOIDCProvider extends Model
         'client_secret',
         'verify_jwt',
         'jwt_public_key',
+        'use_pkce',
     ];
 
     protected function casts(): array
@@ -45,6 +47,7 @@ class GenericOIDCProvider extends Model
             'client_id' => 'encrypted',
             'client_secret' => 'encrypted',
             'verify_jwt' => 'bool',
+            'use_pkce' => 'bool',
         ];
     }
 }


### PR DESCRIPTION
Adds PKCE support to the `generic-oidc-providers` plugin and an option controlling it. If unset, the option falls back to checking if the OIDC provider supports PKCE and enabled if the provider does support it.

I re-used simple "Yes"/"No" strings from admin/server, and only added a string for the option title (Google Translate used for German).

Should be fully backwards compatible, with a net benefit of increasing security and also allowing integration with OIDC providers that require PKCE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable PKCE support for generic OpenID Connect providers.
  * Administrators can set PKCE to enabled, disabled, or automatic detection.
  * Added PKCE configuration visibility and controls in provider settings.
  * Added English and German labels for the new setting.
  * Automatic mode detects provider support when no explicit setting is selected.
* **Updates**
  * Updated the plugin version to 1.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->